### PR TITLE
Improve error message and input support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Note that the user-defined properties do not have any meaning on their own -- it
 Input Name    | Required? | Description
 ----------    | --------- | -----------
 `configuration-path` | No | path to your configuration YAML file (usually `.github/slash-commands.yaml`)
-`repo-token`  | Yes       | the API token to use for access (usually GITHUB_TOKEN)
+`configuration-ref`  | No | commit ref to use when loading configuration file (usually `$GITHUB_SHA`)
+`repo-token`  | No        | the API token to use for access (usually `$GITHUB_TOKEN`)
 
 ## Outputs
 
@@ -52,13 +53,19 @@ Output Name  | Description
 -----------  | -----------
 `message`    | message to add to the user's comment
 `reaction`   | reaction emoji to add to the PR comment
-`result`     | the result body if a command matched, or `{}` if not
+`result`     | JSON-formatted result body if a command matched, or `{}` if not
 
 ## Changelog
 
 Note: for the versions listed below, your workflows can refer to either the version tag (`HBOCodeLabs/parse-slash-command-action@v1.0.5`) or the major version branch (`HBOCodeLabs/parse-slash-command-action@v1`).
 
 The major version branch may be updated with backwards-compatible features and bug fixes. Version tags will not be modified once released.
+
+#### 2021-08-02 - `v1.1.0` (`v1`)
+
+ - The `repo-token` input is now optional, and defaults to `$GITHUB_TOKEN`.
+ - The commit ref to use when loading your configuration file can now be overriden.
+ - Improved error message for incomplete commands.
 
 #### 2021-07-11 - `v1.0.0` (`v1`)
 

--- a/action.yaml
+++ b/action.yaml
@@ -3,11 +3,16 @@ description: 'Building block that parses a slash command and return a custom res
 inputs:
   repo-token:
     description: 'token to use for repo access (typically GITHUB_TOKEN)'
-    required: true
-  configuration-path:
-    description: 'file path to your configuration YAML file'
     required: false
-    default: '.github/slash-command.yaml'
+    default: ${{ github.token }}
+  configuration-path:
+    description: 'load configuration YAML from the specified path'
+    required: false
+    default: '.github/slash-commands.yaml'
+  configuration-ref:
+    description: 'load configuration YAML from the specified ref'
+    required: false
+    default: ${{ github.context.sha }}
 outputs:
   message:
     description: 'a message to add to the triggering comment'

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,11 +7,12 @@ const YAML = require('js-yaml');
 
 const action = {
     async main() {
-        const token = core.getInput('repo-token', { required: true });
-        const configPath = core.getInput('configuration-path') || '.github/slash-commands.yaml'
+        const token = core.getInput('repo-token');
+        const configPath = core.getInput('configuration-path');
+        const configRef = core.getInput('configuration-ref');
 
         const octokit = github.getOctokit(token);
-        const config = await action.getConfig(octokit, configPath);
+        const config = await action.getConfig(octokit, configPath, configRef);
         const comment = github.context.payload.comment.body;
         const args = String(comment).trim().split(/ +/);
 
@@ -27,12 +28,16 @@ const action = {
         let commands = config.commands;
         let consumed = [];
         let result;
+        let incorrectCommand = false;
 
         for (let arg of args) {
             consumed.push(arg);
 
             let command = commands.find(command => command.name === arg);
-            if (!command) break;
+            if (!command) {
+                incorrectCommand = true;
+                break;
+            }
 
             if (command.result) {
                 result = command.result;
@@ -50,20 +55,35 @@ const action = {
         } else {
             let failed = consumed.join(' ');
             let options = commands.map(command => command.name).join(', ');
+            let prefix = 'Unknown command';
             let suggest = consumed.slice(0, -1).concat(`[${options}]`).join(' ');
-            let error = `> Unknown command \`${failed}\` - try one of \`${suggest}\``;
+
+            if (!incorrectCommand) {
+                prefix = 'Incomplete command';
+                suggest = consumed.concat(`[${options}]`).join(' ');
+            }
+
+            let error = `> ${prefix} \`${failed}\` - try one of \`${suggest}\``;
             core.info(`Failed: ${error}`);
             core.setOutput('result', '{}');
             core.setOutput('message', error);
             core.setOutput('reaction', 'confused');
         }
     },
-    async getConfig(octokit, configPath) {
+    async getConfig(octokit, configPath, configRef) {
+        let params = {
+            owner: github.context.repo.owner,
+            repo: github.context.repo.repo,
+            path: configPath,
+            ref: configRef
+        };
+        core.info(`Retrieve: ${JSON.stringify(params)}`);
+
         const response = await octokit.repos.getContent({
             owner: github.context.repo.owner,
             repo: github.context.repo.repo,
             path: configPath,
-            ref: github.context.sha
+            ref: configRef
         });
         const text = Buffer.from(response.data.content, response.data.encoding).toString();
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ const action = {
         const octokit = github.getOctokit(token);
         const config = await action.getConfig(octokit, configPath, configRef);
         const comment = github.context.payload.comment.body;
-        const args = String(comment).trim().split(/ +/);
+        const args = String(comment).trim().split(/[\r\n ]+/);
 
         core.info(`Using config: ${JSON.stringify(config, undefined, 2)}`);
         core.info(`Parsing comment: ${comment}`);

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -65,6 +65,23 @@ describe('parse-slash-command', () => {
             expect(core.setOutput).toHaveBeenCalledWith('reaction', 'rocket');
         });
 
+        it('ignores extra content after a valid command', async () => {
+            github.context = new github.context.constructor();
+            github.context.payload = {
+                comment: {
+                    body: '/order nachos\n\n(the developers are hungry)'
+                }
+            };
+
+            await action.main();
+
+            expect(action.getConfig).toHaveBeenCalledWith(expect.anything(), '.github/slash-commands.yaml', 'aabbcc');
+            expect(core.setOutput).toHaveBeenCalledWith('result', JSON.stringify({
+                action: 'order-nachos'
+            }));
+            expect(core.setOutput).toHaveBeenCalledWith('reaction', 'rocket');
+        });
+
         it('if provided, will load configuration from a custom path and ref', async () => {
             process.env['INPUT_CONFIGURATION-PATH'] = 'commands.yaml';
             process.env['INPUT_CONFIGURATION-REF'] = 'config-branch';
@@ -127,6 +144,21 @@ describe('parse-slash-command', () => {
 
             expect(action.getConfig).toHaveBeenCalledWith(expect.anything(), '.github/slash-commands.yaml', 'aabbcc');
             expect(core.setOutput).toHaveBeenCalledWith('message', '> Incomplete command `/order` - try one of `/order [pizza, nachos]`');
+            expect(core.setOutput).toHaveBeenCalledWith('reaction', 'confused');
+        });
+
+        it('will ignore a valid command if it is not the beginning of the message', async () => {
+            github.context = new github.context.constructor();
+            github.context.payload = {
+                comment: {
+                    body: '/apple /order pizza'
+                }
+            };
+
+            await action.main();
+
+            expect(action.getConfig).toHaveBeenCalledWith(expect.anything(), '.github/slash-commands.yaml', 'aabbcc');
+            expect(core.setOutput).toHaveBeenCalledWith('message', '> Unknown command `/apple` - try one of `[/order]`');
             expect(core.setOutput).toHaveBeenCalledWith('reaction', 'confused');
         });
     });

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -13,6 +13,10 @@ describe('parse-slash-command', () => {
 
         jest.spyOn(core, 'setOutput').mockReturnValue();
         jest.spyOn(core, 'info').mockReturnValue();
+
+        process.env['INPUT_REPO-TOKEN'] = 'cafe43';
+        process.env['INPUT_CONFIGURATION-PATH'] = '.github/slash-commands.yaml';
+        process.env['INPUT_CONFIGURATION-REF'] = 'aabbcc';
     });
 
     afterEach(() => {
@@ -45,7 +49,6 @@ describe('parse-slash-command', () => {
         });
 
         it('returns user-defined props and default reaction if command matches', async () => {
-            process.env['INPUT_REPO-TOKEN'] = 'cafe43';
             github.context = new github.context.constructor();
             github.context.payload = {
                 comment: {
@@ -55,16 +58,16 @@ describe('parse-slash-command', () => {
 
             await action.main();
 
-            expect(action.getConfig).toHaveBeenCalledWith(expect.anything(), '.github/slash-commands.yaml');
+            expect(action.getConfig).toHaveBeenCalledWith(expect.anything(), '.github/slash-commands.yaml', 'aabbcc');
             expect(core.setOutput).toHaveBeenCalledWith('result', JSON.stringify({
                 action: 'order-nachos'
             }));
             expect(core.setOutput).toHaveBeenCalledWith('reaction', 'rocket');
         });
 
-        it('if provided, will load configuration from a custom path', async () => {
-            process.env['INPUT_REPO-TOKEN'] = 'cafe43';
+        it('if provided, will load configuration from a custom path and ref', async () => {
             process.env['INPUT_CONFIGURATION-PATH'] = 'commands.yaml';
+            process.env['INPUT_CONFIGURATION-REF'] = 'config-branch';
 
             github.context = new github.context.constructor();
             github.context.payload = {
@@ -75,7 +78,7 @@ describe('parse-slash-command', () => {
 
             await action.main();
 
-            expect(action.getConfig).toHaveBeenCalledWith(expect.anything(), 'commands.yaml');
+            expect(action.getConfig).toHaveBeenCalledWith(expect.anything(), 'commands.yaml', 'config-branch');
             expect(core.setOutput).toHaveBeenCalledWith('result', JSON.stringify({
                 action: 'order-pizza'
             }));
@@ -83,7 +86,6 @@ describe('parse-slash-command', () => {
         });
 
         it('returns error reaction and message if no command matches', async () => {
-            process.env['INPUT_REPO-TOKEN'] = 'cafe43';
             github.context = new github.context.constructor();
             github.context.payload = {
                 comment: {
@@ -93,13 +95,12 @@ describe('parse-slash-command', () => {
 
             await action.main();
 
-            expect(action.getConfig).toHaveBeenCalledWith(expect.anything(), '.github/slash-commands.yaml');
+            expect(action.getConfig).toHaveBeenCalledWith(expect.anything(), '.github/slash-commands.yaml', 'aabbcc');
             expect(core.setOutput).toHaveBeenCalledWith('message', '> Unknown command `/pizza` - try one of `[/order]`');
             expect(core.setOutput).toHaveBeenCalledWith('reaction', 'confused');
         });
 
         it('returns error reaction and message if a subcommand does not match', async () => {
-            process.env['INPUT_REPO-TOKEN'] = 'cafe43';
             github.context = new github.context.constructor();
             github.context.payload = {
                 comment: {
@@ -109,8 +110,23 @@ describe('parse-slash-command', () => {
 
             await action.main();
 
-            expect(action.getConfig).toHaveBeenCalledWith(expect.anything(), '.github/slash-commands.yaml');
+            expect(action.getConfig).toHaveBeenCalledWith(expect.anything(), '.github/slash-commands.yaml', 'aabbcc');
             expect(core.setOutput).toHaveBeenCalledWith('message', '> Unknown command `/order sirloin` - try one of `/order [pizza, nachos]`');
+            expect(core.setOutput).toHaveBeenCalledWith('reaction', 'confused');
+        });
+
+        it('returns error reaction and message if a command is incomplete', async () => {
+            github.context = new github.context.constructor();
+            github.context.payload = {
+                comment: {
+                    body: '/order '
+                }
+            };
+
+            await action.main();
+
+            expect(action.getConfig).toHaveBeenCalledWith(expect.anything(), '.github/slash-commands.yaml', 'aabbcc');
+            expect(core.setOutput).toHaveBeenCalledWith('message', '> Incomplete command `/order` - try one of `/order [pizza, nachos]`');
             expect(core.setOutput).toHaveBeenCalledWith('reaction', 'confused');
         });
     });
@@ -118,8 +134,6 @@ describe('parse-slash-command', () => {
     describe('getConfig', () => {
         it('returns an object containing the YAML config data from current sha', async () => {
             process.env['GITHUB_REPOSITORY'] = 'AcmeCorp/RocketSled';
-            process.env['GITHUB_REF'] = 'main';
-            process.env['GITHUB_SHA'] = 'aabbccdd';
             github.context = new github.context.constructor();
 
             const mockOctokit = {
@@ -133,14 +147,14 @@ describe('parse-slash-command', () => {
                 }
             };
 
-            const result = await action.getConfig(mockOctokit, 'path/to/config.yaml');
+            const result = await action.getConfig(mockOctokit, 'path/to/config.yaml', 'aabbcc');
 
             expect(result).toEqual({ value1: 3, value2: 4 });
 
             expect(mockOctokit.repos.getContent).toHaveBeenCalledWith({
                 owner: 'AcmeCorp',
                 repo: 'RocketSled',
-                ref: 'aabbccdd',
+                ref: 'aabbcc',
                 path: 'path/to/config.yaml'
             });
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-slash-command-action",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Parse a slash command left in a PR comment.",
   "main": "lib/index.js",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-slash-command-action",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Parse a slash command left in a PR comment.",
   "main": "lib/index.js",
   "private": true,


### PR DESCRIPTION
### SUMMARY

Backwards-compatible input changes and an improved error message.

### DETAILS

 - When a user's command is an incomplete command, improve the error message formatting -- for example, if `/build android` is a supported command, and the user types only `/build`, the error message now clarifies that the command is incomplete and includes `/build` in the example output.

 - The `repo-token` input is now optional and defaults to the sane value (`$GITHUB_TOKEN`).

 - The commit ref used to load the config file is now overridable.

### CHECKLIST
- [x] Documentation updated (if needed)
- [x] Unit tests exist to cover the code you are changing and validated
- [ ] Integration tests exist to cover the code you are changing and validated
