### PR TITLE
Slash commands should have "aliases"

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ Each command can define a nested `commands` property (for longer subcommands). L
 
 Note that the user-defined properties do not have any meaning on their own -- it's up to your workflow to take some action, if appropriate, based on the results from this action.
 
+## Configuration File Format
+
+The configuration file is a YAML file containing an array of `commands`. Each command supports
+the following properties.
+
+Property | Required? | Description
+-------- | --------- | -----------
+name     | Yes       | the name of this command or subcommand
+aliases  | No        | a list of optional aliases that can be used instead of the name
+result   | No        | the user-specified value or object to return for this command
+commands | No        | if specified, a new list of subcommands that can come after this command
+
 ## Inputs
 
 Input Name    | Required? | Description
@@ -60,6 +72,10 @@ Output Name  | Description
 Note: for the versions listed below, your workflows can refer to either the version tag (`HBOCodeLabs/parse-slash-command-action@v1.0.5`) or the major version branch (`HBOCodeLabs/parse-slash-command-action@v1`).
 
 The major version branch may be updated with backwards-compatible features and bug fixes. Version tags will not be modified once released.
+
+#### 2021-09-24 - `v1.2.0` (`v1`)
+
+ - Added support for `aliases` property in command configuration.
 
 #### 2021-08-02 - `v1.1.0` (`v1`)
 

--- a/README.md
+++ b/README.md
@@ -41,15 +41,18 @@ Note that the user-defined properties do not have any meaning on their own -- it
 
 ## Configuration File Format
 
-The configuration file is a YAML file containing an array of `commands`. Each command supports
-the following properties.
+The configuration file is a YAML file containing an array of `commands`. Each command
+should contain either a `result` property, or a nested `commands` array. Commands can
+be nested multiple levels deep.
 
 Property | Required? | Description
 -------- | --------- | -----------
 name     | Yes       | the name of this command or subcommand
 aliases  | No        | a list of optional aliases that can be used instead of the name
-result   | No        | the user-specified value or object to return for this command
-commands | No        | if specified, a new list of subcommands that can come after this command
+result   | No<sup>1</sup> | the user-specified value or object to return for this command
+commands | No<sup>1</sup> | if specified, a new list of subcommands that can come after this command
+
+<sup>1</sup> Either `result` or `commands` is required.
 
 ## Inputs
 
@@ -76,6 +79,7 @@ The major version branch may be updated with backwards-compatible features and b
 #### 2021-09-24 - `v1.2.0` (`v1`)
 
  - Added support for `aliases` property in command configuration.
+ - Added validation for configuration file.
 
 #### 2021-08-02 - `v1.1.0` (`v1`)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,7 @@ const action = {
         // Add in the implied forward slash for the first layer of commands. This makes
         // it easier to parse and format error messages later.
         for (let command of config.commands) {
-            command.name = `/${command.name}`;
+            command.prefix = '/';
         }
 
         let commands = config.commands;
@@ -33,7 +33,7 @@ const action = {
         for (let arg of args) {
             consumed.push(arg);
 
-            let command = commands.find(command => command.name === arg);
+            let command = commands.find(command => action.commandMatches(command, arg));
             if (!command) {
                 incorrectCommand = true;
                 break;
@@ -54,7 +54,7 @@ const action = {
             core.setOutput('reaction', 'rocket');
         } else {
             let failed = consumed.join(' ');
-            let options = commands.map(command => command.name).join(', ');
+            let options = commands.map(command => `${command.prefix || ''}${command.name}`).join(', ');
             let prefix = 'Unknown command';
             let suggest = consumed.slice(0, -1).concat(`[${options}]`).join(' ');
 
@@ -88,6 +88,21 @@ const action = {
         const text = Buffer.from(response.data.content, response.data.encoding).toString();
 
         return YAML.load(text);
+    },
+    commandMatches(command, arg) {
+        let prefix = command.prefix || '';
+        let aliases = command.aliases || [];
+
+        if (!Array.isArray(aliases)) {
+            aliases = [aliases];
+        }
+
+        if (prefix + command.name === arg) return true;
+        for (let alias of aliases) {
+            if (prefix + alias === arg) return true;
+        }
+
+        return false;
     }
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,18 +16,17 @@ const action = {
         const comment = github.context.payload.comment.body;
         const args = String(comment).trim().split(/[\r\n ]+/);
 
+        // Remove leading slash
+        if (args[0] && args[0][0] === '/') {
+            args[0] = args[0].slice(1);
+        }
+
         core.info(`Validating config: ${JSON.stringify(config, undefined, 2)}`);
 
         try {
             this.validateConfig(config);
         } catch (error) {
             return this.fail(error.message);
-        }
-
-        // Add in the implied forward slash for the first layer of commands. This makes
-        // it easier to parse and format error messages later.
-        for (let command of config.commands) {
-            command.prefix = '/';
         }
 
         core.info(`Parsing comment: ${comment}`);
@@ -59,14 +58,16 @@ const action = {
         if (result) {
             return this.succeed(result);
         } else {
-            let failed = consumed.join(' ');
-            let options = commands.map(command => `${command.prefix || ''}${command.name}`).join(', ');
+            let consumedWithSlash = consumed.map((c, idx) => idx === 0 ? `/${c}` : c);
+            let failed = consumedWithSlash.join(' ');
+            let optionPrefix = (incorrectCommand && consumed.length === 1) ? '/' : '';
+            let options = commands.map(command => optionPrefix + command.name).join(', ');
             let prefix = 'Unknown command';
-            let suggest = consumed.slice(0, -1).concat(`[${options}]`).join(' ');
+            let suggest = consumedWithSlash.slice(0, -1).concat(`[${options}]`).join(' ');
 
             if (!incorrectCommand) {
                 prefix = 'Incomplete command';
-                suggest = consumed.concat(`[${options}]`).join(' ');
+                suggest = consumedWithSlash.concat(`[${options}]`).join(' ');
             }
 
             let error = `${prefix} \`${failed}\` - try one of \`${suggest}\``;
@@ -106,7 +107,7 @@ const action = {
                 throw new Error(`Configuration error: a command is missing the \`name\` property`);
             }
 
-            context = context.concat(`${command.prefix || ''}${command.name}`);
+            context = context.concat(command.name);
 
             if (command.result && command.commands) {
                 throw new Error(`Configuration error: \`${context.join(' ')}\` must contain either a \`result\` or \`commands\` property, but not both`);
@@ -123,19 +124,13 @@ const action = {
         }
     },
     commandMatches(command, arg) {
-        let prefix = command.prefix || '';
         let aliases = command.aliases || [];
 
         if (!Array.isArray(aliases)) {
             aliases = [aliases];
         }
 
-        if (prefix + command.name === arg) return true;
-        for (let alias of aliases) {
-            if (prefix + alias === arg) return true;
-        }
-
-        return false;
+        return (command.name === arg || aliases.includes(arg));
     },
     succeed(result, message) {
         core.info(`Success: ${JSON.stringify(result)}`);

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,14 +16,21 @@ const action = {
         const comment = github.context.payload.comment.body;
         const args = String(comment).trim().split(/[\r\n ]+/);
 
-        core.info(`Using config: ${JSON.stringify(config, undefined, 2)}`);
-        core.info(`Parsing comment: ${comment}`);
+        core.info(`Validating config: ${JSON.stringify(config, undefined, 2)}`);
+
+        try {
+            this.validateConfig(config);
+        } catch (error) {
+            return this.fail(error.message);
+        }
 
         // Add in the implied forward slash for the first layer of commands. This makes
         // it easier to parse and format error messages later.
         for (let command of config.commands) {
             command.prefix = '/';
         }
+
+        core.info(`Parsing comment: ${comment}`);
 
         let commands = config.commands;
         let consumed = [];
@@ -41,6 +48,7 @@ const action = {
 
             if (command.result) {
                 result = command.result;
+                break;
             }
 
             if (command.commands) {
@@ -49,9 +57,7 @@ const action = {
         }
 
         if (result) {
-            core.info(`Success: ${JSON.stringify(result)}`);
-            core.setOutput('result', JSON.stringify(result));
-            core.setOutput('reaction', 'rocket');
+            return this.succeed(result);
         } else {
             let failed = consumed.join(' ');
             let options = commands.map(command => `${command.prefix || ''}${command.name}`).join(', ');
@@ -63,11 +69,8 @@ const action = {
                 suggest = consumed.concat(`[${options}]`).join(' ');
             }
 
-            let error = `> ${prefix} \`${failed}\` - try one of \`${suggest}\``;
-            core.info(`Failed: ${error}`);
-            core.setOutput('result', '{}');
-            core.setOutput('message', error);
-            core.setOutput('reaction', 'confused');
+            let error = `${prefix} \`${failed}\` - try one of \`${suggest}\``;
+            return this.fail(error);
         }
     },
     async getConfig(octokit, configPath, configRef) {
@@ -89,6 +92,36 @@ const action = {
 
         return YAML.load(text);
     },
+    validateConfig(config) {
+        if (!config || !Array.isArray(config.commands)) {
+            throw new Error(`Configuration error: missing \`commands\` array`);
+        }
+
+        let queue = config.commands.map(command => ({ context: [], command }));
+
+        while (queue.length > 0) {
+            let { context, command } = queue.shift();
+
+            if (!command.name) {
+                throw new Error(`Configuration error: a command is missing the \`name\` property`);
+            }
+
+            context = context.concat(`${command.prefix || ''}${command.name}`);
+
+            if (command.result && command.commands) {
+                throw new Error(`Configuration error: \`${context.join(' ')}\` must contain either a \`result\` or \`commands\` property, but not both`);
+            } else if (command.result) {
+                // ok
+            } else if (command.commands) {
+                queue.push(...command.commands.map(subcommand => ({
+                    command: subcommand,
+                    context
+                })));
+            } else {
+                throw new Error(`Configuration error: \`${context.join(' ')}\` must contain either a \`result\` or \`commands\` property`);
+            }
+        }
+    },
     commandMatches(command, arg) {
         let prefix = command.prefix || '';
         let aliases = command.aliases || [];
@@ -103,6 +136,20 @@ const action = {
         }
 
         return false;
+    },
+    succeed(result, message) {
+        core.info(`Success: ${JSON.stringify(result)}`);
+        core.setOutput('result', JSON.stringify(result));
+        if (message) {
+            core.setOutput('message', `> ${message}`);
+        }
+        core.setOutput('reaction', 'rocket');
+    },
+    fail(message) {
+        core.info(`Failed: ${message}`);
+        core.setOutput('result', '{}');
+        core.setOutput('message', `> ${message}`);
+        core.setOutput('reaction', 'confused');
     }
 };
 

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -29,6 +29,7 @@ describe('parse-slash-command', () => {
                 commands: [
                     {
                         name: 'order',
+                        aliases: 'gimme',
                         commands: [
                             {
                                 name: 'pizza',
@@ -38,6 +39,7 @@ describe('parse-slash-command', () => {
                             },
                             {
                                 name: 'nachos',
+                                aliases: ['chips', 'cheese'],
                                 result: {
                                     action: 'order-nachos'
                                 }
@@ -53,6 +55,23 @@ describe('parse-slash-command', () => {
             github.context.payload = {
                 comment: {
                     body: '/order nachos'
+                }
+            };
+
+            await action.main();
+
+            expect(action.getConfig).toHaveBeenCalledWith(expect.anything(), '.github/slash-commands.yaml', 'aabbcc');
+            expect(core.setOutput).toHaveBeenCalledWith('result', JSON.stringify({
+                action: 'order-nachos'
+            }));
+            expect(core.setOutput).toHaveBeenCalledWith('reaction', 'rocket');
+        });
+
+        it('returns user-defined props and default reaction if command matches using aliases', async () => {
+            github.context = new github.context.constructor();
+            github.context.payload = {
+                comment: {
+                    body: '/gimme chips'
                 }
             };
 
@@ -144,6 +163,21 @@ describe('parse-slash-command', () => {
 
             expect(action.getConfig).toHaveBeenCalledWith(expect.anything(), '.github/slash-commands.yaml', 'aabbcc');
             expect(core.setOutput).toHaveBeenCalledWith('message', '> Incomplete command `/order` - try one of `/order [pizza, nachos]`');
+            expect(core.setOutput).toHaveBeenCalledWith('reaction', 'confused');
+        });
+
+        it('returns error reaction and message, containing an alias, if command is incomplete', async () => {
+            github.context = new github.context.constructor();
+            github.context.payload = {
+                comment: {
+                    body: '/gimme '
+                }
+            };
+
+            await action.main();
+
+            expect(action.getConfig).toHaveBeenCalledWith(expect.anything(), '.github/slash-commands.yaml', 'aabbcc');
+            expect(core.setOutput).toHaveBeenCalledWith('message', '> Incomplete command `/gimme` - try one of `/gimme [pizza, nachos]`');
             expect(core.setOutput).toHaveBeenCalledWith('reaction', 'confused');
         });
 

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -195,6 +195,91 @@ describe('parse-slash-command', () => {
             expect(core.setOutput).toHaveBeenCalledWith('message', '> Unknown command `/apple` - try one of `[/order]`');
             expect(core.setOutput).toHaveBeenCalledWith('reaction', 'confused');
         });
+
+        it('produces a configuration error if there is no commands array', async () => {
+            action.getConfig.mockReturnValue({});
+            github.context = new github.context.constructor();
+            github.context.payload = {
+                comment: {
+                    body: '/order pizza'
+                }
+            };
+
+            await action.main();
+
+            expect(core.setOutput).toHaveBeenCalledWith('message', '> Configuration error: missing `commands` array');
+            expect(core.setOutput).toHaveBeenCalledWith('reaction', 'confused');
+        });
+
+        it('produces a configuration error if a command is missing a name', async () => {
+            action.getConfig.mockReturnValue({
+                commands: [
+                    {
+                        result: 'abc'
+                    }
+                ]
+            });
+            github.context = new github.context.constructor();
+            github.context.payload = {
+                comment: {
+                    body: '/order pizza'
+                }
+            };
+
+            await action.main();
+
+            expect(core.setOutput).toHaveBeenCalledWith('message', '> Configuration error: a command is missing the `name` property');
+            expect(core.setOutput).toHaveBeenCalledWith('reaction', 'confused');
+        });
+
+        it('produces a configuration error if a command has no result or commands properties', async () => {
+            action.getConfig.mockReturnValue({
+                commands: [
+                    {
+                        name: 'order'
+                    }
+                ]
+            });
+            github.context = new github.context.constructor();
+            github.context.payload = {
+                comment: {
+                    body: '/order pizza'
+                }
+            };
+
+            await action.main();
+
+            expect(core.setOutput).toHaveBeenCalledWith('message', '> Configuration error: `order` must contain either a `result` or `commands` property');
+            expect(core.setOutput).toHaveBeenCalledWith('reaction', 'confused');
+        });
+
+        it('produces a configuration error if a command has both result and commands properties', async () => {
+            action.getConfig.mockReturnValue({
+                commands: [
+                    {
+                        name: 'order',
+                        commands: [
+                            {
+                                name: 'pizza',
+                                result: { order: 'pizza' },
+                                commands: []
+                            }
+                        ]
+                    }
+                ]
+            });
+            github.context = new github.context.constructor();
+            github.context.payload = {
+                comment: {
+                    body: '/random other command'
+                }
+            };
+
+            await action.main();
+
+            expect(core.setOutput).toHaveBeenCalledWith('message', '> Configuration error: `order pizza` must contain either a `result` or `commands` property, but not both');
+            expect(core.setOutput).toHaveBeenCalledWith('reaction', 'confused');
+        });
     });
 
     describe('getConfig', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-slash-command-action",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Parse a slash command left in a PR comment.",
   "main": "lib/index.js",
   "private": true,


### PR DESCRIPTION
### SUMMARY

We should allow commands and subcommands to have a list of "aliases" that also work, in addition to their standard names.  (For example, the subcommand might be called "appletv", but we want to also allow "tvos".)

### DETAILS

This functionality is already possible by just duplicating entries in your list of subcommands with different names, but this becomes cumbersome to maintain (you might accidentally update one entry and not another).  It also ends up showing all the possible aliases of a command in the list of options if we produce error text, which isn't ideal.

 - New `aliases` optional property is supported under a command.
 - We support a YAML array or an individual entry (string).
 - These aliases are processed as if they are the correct command name, but are not listed as options in the error text.

### CHECKLIST
- [x] Documentation updated (if needed)
- [x] Unit tests exist to cover the code you are changing and validated
- [ ] Integration tests exist to cover the code you are changing and validated
